### PR TITLE
[release-2.2] no longer generate labels without prefix

### DIFF
--- a/pkg/controller/sync/template_sync.go
+++ b/pkg/controller/sync/template_sync.go
@@ -171,15 +171,11 @@ func (r *ReconcilePolicy) Reconcile(request reconcile.Request) (reconcile.Result
 				labels := tObjectUnstructured.GetLabels()
 				if labels == nil {
 					labels = map[string]string{
-						"cluster-name":               instance.GetLabels()[common.ClusterNameLabel],
 						common.ClusterNameLabel:      instance.GetLabels()[common.ClusterNameLabel],
-						"cluster-namespace":          instance.GetLabels()[common.ClusterNamespaceLabel],
 						common.ClusterNamespaceLabel: instance.GetLabels()[common.ClusterNamespaceLabel],
 					}
 				} else {
-					labels["cluster-name"] = instance.GetLabels()[common.ClusterNameLabel]
 					labels[common.ClusterNameLabel] = instance.GetLabels()[common.ClusterNameLabel]
-					labels["cluster-namespace"] = instance.GetLabels()[common.ClusterNamespaceLabel]
 					labels[common.ClusterNamespaceLabel] = instance.GetLabels()[common.ClusterNamespaceLabel]
 				}
 				tObjectUnstructured.SetLabels(labels)

--- a/test/e2e/case1_template_sync_test.go
+++ b/test/e2e/case1_template_sync_test.go
@@ -65,12 +65,8 @@ var _ = Describe("Test spec sync", func() {
 		trustedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrTrustedContainerPolicy, cast1TrustedContainerPolicyName, testNamespace, true, defaultTimeoutSeconds)
 		Expect(plc.Object["metadata"].(map[string]interface{})["labels"].(map[string]interface{})[common.ClusterNameLabel]).To(
 			utils.SemanticEqual(trustedPlc.Object["metadata"].(map[string]interface{})["labels"].(map[string]interface{})[common.ClusterNameLabel]))
-		Expect(plc.Object["metadata"].(map[string]interface{})["labels"].(map[string]interface{})[common.ClusterNameLabel]).To(
-			utils.SemanticEqual(trustedPlc.Object["metadata"].(map[string]interface{})["labels"].(map[string]interface{})["cluster-name"]))
 		Expect(plc.Object["metadata"].(map[string]interface{})["labels"].(map[string]interface{})[common.ClusterNamespaceLabel]).To(
 			utils.SemanticEqual(trustedPlc.Object["metadata"].(map[string]interface{})["labels"].(map[string]interface{})[common.ClusterNamespaceLabel]))
-		Expect(plc.Object["metadata"].(map[string]interface{})["labels"].(map[string]interface{})[common.ClusterNamespaceLabel]).To(
-			utils.SemanticEqual(trustedPlc.Object["metadata"].(map[string]interface{})["labels"].(map[string]interface{})["cluster-namespace"]))
 	})
 	It("should delete template policy on managed cluster", func() {
 		By("Deleting parent policy")


### PR DESCRIPTION
shouldn't need these anymore
<img width="1197" alt="image" src="https://user-images.githubusercontent.com/16092291/95341627-76657d00-0884-11eb-9376-ebda5c0409d3.png">
