### PR TITLE
Update Annotations

### DIFF
--- a/pkg/controller/sync/template_sync.go
+++ b/pkg/controller/sync/template_sync.go
@@ -232,12 +232,14 @@ func (r *ReconcilePolicy) Reconcile(request reconcile.Request) (reconcile.Result
 		}
 
 		overrideRemediationAction(instance, tObjectUnstructured)
-		// got object, need to compare and update
+		// got object, need to compare both spec and annotation and update
 		eObjectUnstructured := eObject.UnstructuredContent()
-		if !equality.Semantic.DeepEqual(eObjectUnstructured["spec"], tObjectUnstructured.Object["spec"]) {
+		if (!equality.Semantic.DeepEqual(eObjectUnstructured["spec"], tObjectUnstructured.Object["spec"])) ||
+			(!equality.Semantic.DeepEqual(eObject.GetAnnotations(), tObjectUnstructured.GetAnnotations())) {
 			// doesn't match
 			reqLogger.Info("existing object and template don't match, updating...", "PolicyTemplateName", tName)
 			eObjectUnstructured["spec"] = tObjectUnstructured.Object["spec"]
+			eObject.SetAnnotations(tObjectUnstructured.GetAnnotations())
 			_, err = res.Update(context.TODO(), eObject, metav1.UpdateOptions{})
 			if err != nil {
 				reqLogger.Error(err, "Failed to update policy template...", "PolicyTemplateName", tName)


### PR DESCRIPTION
Signed-off-by: ckandag <ckandaga@redhat.com>

On the Create path template annotations in the policy are synced on the managedcluster but 
on update path , only changes to the Spec are being checked and updated.
Need to update the annotations as well, especially now since we are using the annotation to pass error msgs between hub and managedcluster