### PR TITLE
Use the latest tag instead of latest-dev

### DIFF
--- a/deploy/manager/manager.yaml
+++ b/deploy/manager/manager.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: governance-policy-template-sync
       containers:
         - name: governance-policy-template-sync
-          image: quay.io/open-cluster-management/governance-policy-template-sync:latest-dev
+          image: quay.io/open-cluster-management/governance-policy-template-sync:latest
           command:
           - governance-policy-template-sync
           imagePullPolicy: Always

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -135,7 +135,7 @@ spec:
               fieldPath: metadata.name
         - name: OPERATOR_NAME
           value: governance-policy-template-sync
-        image: quay.io/open-cluster-management/governance-policy-template-sync:latest-dev
+        image: quay.io/open-cluster-management/governance-policy-template-sync:latest
         imagePullPolicy: Always
         name: governance-policy-template-sync
       serviceAccountName: governance-policy-template-sync


### PR DESCRIPTION
The latest-dev images are old and no longer used. We are pushing new
changes to latest instead.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>