### PR TITLE
update annotations (#58)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ kind-delete-cluster:
 
 install-crds:
 	@echo installing crds
-	kubectl apply -f https://raw.githubusercontent.com/open-cluster-management/governance-policy-propagator/main/deploy/crds/policy.open-cluster-management.io_policies_crd.yaml
+	kubectl apply -f https://raw.githubusercontent.com/open-cluster-management/governance-policy-propagator/release-2.3/deploy/crds/policy.open-cluster-management.io_policies_crd.yaml
 
 install-resources:
 	@echo creating namespaces

--- a/pkg/controller/sync/template_sync.go
+++ b/pkg/controller/sync/template_sync.go
@@ -229,12 +229,14 @@ func (r *ReconcilePolicy) Reconcile(request reconcile.Request) (reconcile.Result
 		}
 
 		overrideRemediationAction(instance, tObjectUnstructured)
-		// got object, need to compare and update
+		// got object, need to compare both spec and annotation and update
 		eObjectUnstructured := eObject.UnstructuredContent()
-		if !equality.Semantic.DeepEqual(eObjectUnstructured["spec"], tObjectUnstructured.Object["spec"]) {
+		if (!equality.Semantic.DeepEqual(eObjectUnstructured["spec"], tObjectUnstructured.Object["spec"])) ||
+			(!equality.Semantic.DeepEqual(eObject.GetAnnotations(), tObjectUnstructured.GetAnnotations())) {
 			// doesn't match
 			reqLogger.Info("existing object and template don't match, updating...", "PolicyTemplateName", tName)
 			eObjectUnstructured["spec"] = tObjectUnstructured.Object["spec"]
+			eObject.SetAnnotations(tObjectUnstructured.GetAnnotations())
 			_, err = res.Update(context.TODO(), eObject, metav1.UpdateOptions{})
 			if err != nil {
 				reqLogger.Error(err, "Failed to update policy template...", "PolicyTemplateName", tName)


### PR DESCRIPTION
Signed-off-by: ckandag <ckandaga@redhat.com>

Cherry-picked commit to release-2.3 that allows policy annotation to be synced correctly on Managed-clusters.

We need annotations to be correctly synced in-order to Support  "Disable templates" annotation.
related issue: https://github.com/open-cluster-management/backlog/issues/16674