### PR TITLE
Fix tests

### DIFF
--- a/test/e2e/case1_template_sync_test.go
+++ b/test/e2e/case1_template_sync_test.go
@@ -20,13 +20,14 @@ const cast1TrustedContainerPolicyName string = "case1-test-policy-trustedcontain
 var _ = Describe("Test spec sync", func() {
 	BeforeEach(func() {
 		By("Creating a policy on managed cluster in ns:" + testNamespace)
-		utils.Kubectl("apply", "-f", case1PolicyYaml, "-n", testNamespace)
+		_, err := utils.KubectlWithOutput("apply", "-f", case1PolicyYaml, "-n", testNamespace)
+		Expect(err).Should(BeNil())
 		plc := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy, case1PolicyName, testNamespace, true, defaultTimeoutSeconds)
 		Expect(plc).NotTo(BeNil())
 	})
 	AfterEach(func() {
 		By("Deleting a policy on managed cluster in ns:" + testNamespace)
-		utils.Kubectl("delete", "-f", case1PolicyYaml, "-n", testNamespace)
+		utils.KubectlWithOutput("delete", "-f", case1PolicyYaml, "-n", testNamespace)
 		opt := metav1.ListOptions{}
 		utils.ListWithTimeout(clientManagedDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
 	})
@@ -54,7 +55,8 @@ var _ = Describe("Test spec sync", func() {
 	})
 	It("should still override remediationAction in spec when there is no remediationAction", func() {
 		By("Updating policy with no remediationAction")
-		utils.Kubectl("apply", "-f", "../resources/case1_template_sync/case1-test-policy-no-remediation.yaml", "-n", testNamespace)
+		_, err := utils.KubectlWithOutput("apply", "-f", "../resources/case1_template_sync/case1-test-policy-no-remediation.yaml", "-n", testNamespace)
+		Expect(err).Should(BeNil())
 		By("Checking template policy remediationAction")
 		yamlTrustedPlc := utils.ParseYaml("../resources/case1_template_sync/case1-trusted-container-policy-enforce.yaml")
 		Eventually(func() interface{} {
@@ -77,7 +79,8 @@ var _ = Describe("Test spec sync", func() {
 	})
 	It("should delete template policy on managed cluster", func() {
 		By("Deleting parent policy")
-		utils.Kubectl("delete", "-f", case1PolicyYaml, "-n", testNamespace)
+		_, err := utils.KubectlWithOutput("delete", "-f", case1PolicyYaml, "-n", testNamespace)
+		Expect(err).Should(BeNil())
 		opt := metav1.ListOptions{}
 		utils.ListWithTimeout(clientManagedDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
 		By("Checking the existence of template policy")

--- a/test/e2e/case2_error_test.go
+++ b/test/e2e/case2_error_test.go
@@ -15,16 +15,18 @@ import (
 var _ = Describe("Test error handling", func() {
 	It("should not override remediationAction if doesn't exist on parent policy", func() {
 		By("Creating ../resources/case2_error_test/remediation-action-not-exists.yaml on managed cluster in ns:" + testNamespace)
-		utils.Kubectl("apply", "-f", "../resources/case2_error_test/remediation-action-not-exists.yaml",
+		_, err := utils.KubectlWithOutput("apply", "-f", "../resources/case2_error_test/remediation-action-not-exists.yaml",
 			"-n", testNamespace)
+		Expect(err).Should(BeNil())
 		Eventually(func() interface{} {
 			trustedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrTrustedContainerPolicy,
 				"case2-remedation-action-not-exists-trustedcontainerpolicy", testNamespace, true, defaultTimeoutSeconds)
 			return trustedPlc.Object["spec"].(map[string]interface{})["remediationAction"]
 		}, defaultTimeoutSeconds, 1).Should(Equal("inform"))
 		By("Patching ../resources/case2_error_test/remediation-action-not-exists2.yaml on managed cluster in ns:" + testNamespace)
-		utils.Kubectl("apply", "-f", "../resources/case2_error_test/remediation-action-not-exists2.yaml",
+		_, err = utils.KubectlWithOutput("apply", "-f", "../resources/case2_error_test/remediation-action-not-exists2.yaml",
 			"-n", testNamespace)
+		Expect(err).Should(BeNil())
 		By("Checking the case2-remedation-action-not-exists-trustedcontainerpolicy CR")
 		yamlTrustedPlc := utils.ParseYaml("../resources/case2_error_test/remedation-action-not-exists-trustedcontainerpolicy.yaml")
 		Eventually(func() interface{} {
@@ -33,60 +35,71 @@ var _ = Describe("Test error handling", func() {
 			return trustedPlc.Object["spec"]
 		}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlTrustedPlc.Object["spec"]))
 		By("Deleting ../resources/case2_error_test/remediation-action-not-exists.yaml to clean up")
-		utils.Kubectl("delete", "-f", "../resources/case2_error_test/remediation-action-not-exists.yaml",
+		_, err = utils.KubectlWithOutput("delete", "-f", "../resources/case2_error_test/remediation-action-not-exists.yaml",
 			"-n", testNamespace)
+		Expect(err).Should(BeNil())
 		utils.ListWithTimeout(clientManagedDynamic, gvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
 	})
 	It("should not break if no spec", func() {
 		By("Creating ../resources/case2_error_test/no-spec.yaml on managed cluster in ns:" + testNamespace)
-		utils.Kubectl("apply", "-f", "../resources/case2_error_test/no-spec.yaml",
+		_, err := utils.KubectlWithOutput("apply", "-f", "../resources/case2_error_test/no-spec.yaml",
 			"-n", testNamespace)
+		Expect(err).Should(BeNil())
 		By("Checking if policy was created on managed cluster in ns:" + testNamespace)
 		utils.GetWithTimeout(clientManagedDynamic, gvrPolicy, "default.case2-no-spec", testNamespace, true, defaultTimeoutSeconds)
 		By("Deleting ../resources/case2_error_test/no-spec.yam to clean up")
-		utils.Kubectl("delete", "-f", "../resources/case2_error_test/no-spec.yaml",
+		_, err = utils.KubectlWithOutput("delete", "-f", "../resources/case2_error_test/no-spec.yaml",
 			"-n", testNamespace)
+		Expect(err).Should(BeNil())
 		utils.ListWithTimeout(clientManagedDynamic, gvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
 	})
 	It("should generate decode err event", func() {
 		By("Creating ../resources/case2_error_test/template-decode-error.yaml on managed cluster in ns:" + testNamespace)
-		utils.Kubectl("apply", "-f", "../resources/case2_error_test/template-decode-error.yaml",
+		_, err := utils.KubectlWithOutput("apply", "-f", "../resources/case2_error_test/template-decode-error.yaml",
 			"-n", testNamespace)
+		Expect(err).Should(BeNil())
 		By("Creating event with decode err on managed cluster in ns:" + testNamespace)
 		eventList := utils.ListWithTimeout(clientManagedDynamic, gvrEvent, metav1.ListOptions{FieldSelector: "involvedObject.name=default.case2-template-decode-error"}, 1, true, defaultTimeoutSeconds)
 		By("Deleting the event to clean up")
 		event := eventList.Items[0]
-		utils.Kubectl("delete", "event", event.GetName(), "-n", testNamespace)
+		_, err = utils.KubectlWithOutput("delete", "event", event.GetName(), "-n", testNamespace)
+		Expect(err).Should(BeNil())
 		eventList = utils.ListWithTimeout(clientManagedDynamic, gvrEvent, metav1.ListOptions{FieldSelector: "involvedObject.name=default.case2-template-decode-error"}, 0, true, defaultTimeoutSeconds)
 		By("Deleting ../resources/case2_error_test/template-decode-error.yaml to clean up")
-		utils.Kubectl("delete", "-f", "../resources/case2_error_test/template-decode-error.yaml",
+		_, err = utils.KubectlWithOutput("delete", "-f", "../resources/case2_error_test/template-decode-error.yaml",
 			"-n", testNamespace)
+		Expect(err).Should(BeNil())
 		utils.ListWithTimeout(clientManagedDynamic, gvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
 	})
 	It("should generate mapping err event", func() {
 		By("Creating ../resources/case2_error_test/template-mapping-error.yaml on managed cluster in ns:" + testNamespace)
-		utils.Kubectl("apply", "-f", "../resources/case2_error_test/template-mapping-error.yaml",
+		_, err := utils.KubectlWithOutput("apply", "-f", "../resources/case2_error_test/template-mapping-error.yaml",
 			"-n", testNamespace)
+		Expect(err).Should(BeNil())
 		By("Creating event with decode err on managed cluster in ns:" + testNamespace)
 		eventList := utils.ListWithTimeout(clientManagedDynamic, gvrEvent, metav1.ListOptions{FieldSelector: "involvedObject.name=default.case2-template-mapping-error"}, 2, true, defaultTimeoutSeconds)
 		By("Deleting the event to clean up")
 		for _, event := range eventList.Items {
-			utils.Kubectl("delete", "event", event.GetName(), "-n", testNamespace)
+			_, err = utils.KubectlWithOutput("delete", "event", event.GetName(), "-n", testNamespace)
+			Expect(err).Should(BeNil())
 		}
 		eventList = utils.ListWithTimeout(clientManagedDynamic, gvrEvent, metav1.ListOptions{FieldSelector: "involvedObject.name=default.case2-template-mapping-error"}, 0, true, defaultTimeoutSeconds)
 		By("Deleting ../resources/case2_error_test/template-mapping-error.yaml to clean up")
-		utils.Kubectl("delete", "-f", "../resources/case2_error_test/template-mapping-error.yaml",
+		_, err = utils.KubectlWithOutput("delete", "-f", "../resources/case2_error_test/template-mapping-error.yaml",
 			"-n", testNamespace)
+		Expect(err).Should(BeNil())
 		utils.ListWithTimeout(clientManagedDynamic, gvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
 	})
 	It("should generate duplicate policy template err event", func() {
 		By("Creating ../resources/case2_error_test/working-policy-duplicate.yaml on managed cluster in ns:" + testNamespace)
-		utils.Kubectl("apply", "-f", "../resources/case2_error_test/working-policy.yaml",
+		_, err := utils.KubectlWithOutput("apply", "-f", "../resources/case2_error_test/working-policy.yaml",
 			"-n", testNamespace)
+		Expect(err).Should(BeNil())
 		//wait for original policy to be processed before creating duplicate policy
 		time.Sleep(30 * time.Second)
-		utils.Kubectl("apply", "-f", "../resources/case2_error_test/working-policy-duplicate.yaml",
+		_, err = utils.KubectlWithOutput("apply", "-f", "../resources/case2_error_test/working-policy-duplicate.yaml",
 			"-n", testNamespace)
+		Expect(err).Should(BeNil())
 		By("Creating event with duplicate err on managed cluster in ns:" + testNamespace)
 		eventList := utils.ListWithTimeout(clientManagedDynamic, gvrEvent, metav1.ListOptions{FieldSelector: "involvedObject.name=default.case2-test-policy-duplicate"}, 2, true, defaultTimeoutSeconds)
 		violationStringFound := false
@@ -99,14 +112,17 @@ var _ = Describe("Test error handling", func() {
 		Expect(violationStringFound).To(BeTrue())
 		By("Deleting the event to clean up")
 		for _, event := range eventList.Items {
-			utils.Kubectl("delete", "event", event.GetName(), "-n", testNamespace)
+			_, err = utils.KubectlWithOutput("delete", "event", event.GetName(), "-n", testNamespace)
+			Expect(err).Should(BeNil())
 		}
 		eventList = utils.ListWithTimeout(clientManagedDynamic, gvrEvent, metav1.ListOptions{FieldSelector: "involvedObject.name=default.case2-test-policy-duplicate"}, 0, true, defaultTimeoutSeconds)
 		By("Deleting policies to clean up")
-		utils.Kubectl("delete", "-f", "../resources/case2_error_test/working-policy.yaml",
+		_, err = utils.KubectlWithOutput("delete", "-f", "../resources/case2_error_test/working-policy.yaml",
 			"-n", testNamespace)
-		utils.Kubectl("delete", "-f", "../resources/case2_error_test/working-policy-duplicate.yaml",
+		Expect(err).Should(BeNil())
+		_, err = utils.KubectlWithOutput("delete", "-f", "../resources/case2_error_test/working-policy-duplicate.yaml",
 			"-n", testNamespace)
+		Expect(err).Should(BeNil())
 		utils.ListWithTimeout(clientManagedDynamic, gvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
 	})
 })

--- a/test/e2e/case2_error_test.go
+++ b/test/e2e/case2_error_test.go
@@ -40,19 +40,6 @@ var _ = Describe("Test error handling", func() {
 		Expect(err).Should(BeNil())
 		utils.ListWithTimeout(clientManagedDynamic, gvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
 	})
-	It("should not break if no spec", func() {
-		By("Creating ../resources/case2_error_test/no-spec.yaml on managed cluster in ns:" + testNamespace)
-		_, err := utils.KubectlWithOutput("apply", "-f", "../resources/case2_error_test/no-spec.yaml",
-			"-n", testNamespace)
-		Expect(err).Should(BeNil())
-		By("Checking if policy was created on managed cluster in ns:" + testNamespace)
-		utils.GetWithTimeout(clientManagedDynamic, gvrPolicy, "default.case2-no-spec", testNamespace, true, defaultTimeoutSeconds)
-		By("Deleting ../resources/case2_error_test/no-spec.yam to clean up")
-		_, err = utils.KubectlWithOutput("delete", "-f", "../resources/case2_error_test/no-spec.yaml",
-			"-n", testNamespace)
-		Expect(err).Should(BeNil())
-		utils.ListWithTimeout(clientManagedDynamic, gvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
-	})
 	It("should generate decode err event", func() {
 		By("Creating ../resources/case2_error_test/template-decode-error.yaml on managed cluster in ns:" + testNamespace)
 		_, err := utils.KubectlWithOutput("apply", "-f", "../resources/case2_error_test/template-decode-error.yaml",

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -69,7 +69,8 @@ var _ = BeforeSuite(func() {
 		}, metav1.CreateOptions{})).NotTo(BeNil())
 	}
 	By("Create trustedcontainerpolicy CRD")
-	utils.Kubectl("apply", "-f", "../resources/policies.ibm.com_trustedcontainerpolicies_crd.yaml")
+	_, err := utils.KubectlWithOutput("apply", "-f", "../resources/policies.ibm.com_trustedcontainerpolicies_crd.yaml")
+	Expect(err).Should(BeNil())
 })
 
 func NewKubeClient(url, kubeconfig, context string) kubernetes.Interface {


### PR DESCRIPTION
The normal `Kubectl` test function does not wait for the command to
return, which means it can fail silently, or cause concurrency problems.
The KubectlWithOutput command waits for the command to complete, and we
can just discard the output and check the error.

Additionally, one test should be removed - it checks that a Policy can be
created without a `spec`, which is no longer true: https://github.com/open-cluster-management/governance-policy-propagator/blob/main/deploy/crds/policy.open-cluster-management.io_policies.yaml#L151